### PR TITLE
accommodate invalid column names as model definition names

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,9 @@ Developmental version, to be released as v0.2.0.
   racing methods.
 * Integrate with {tune} functionality for appropriately coloring errors, 
   warnings, and messages.
+* Fixed bug arising from  model definition names that are not valid column 
+  names. The package will now message in the case that the provided names
+  are not valid column names and use `make.names` for associated candidate members.
 * Various bug fixes and improvements to documentation.
 
 ### v0.1.0

--- a/R/add_candidates.R
+++ b/R/add_candidates.R
@@ -120,7 +120,7 @@ add_candidates.tune_results <- function(data_stack, candidates,
     .set_outcome(candidates) %>%
     .set_mode_(candidates, name) %>%
     .set_training_data(candidates, name) %>%
-    .set_model_defs_candidates(candidates, col_name) %>%
+    .set_model_defs_candidates(candidates, name) %>%
     .set_data_candidates(candidates, name, col_name)
   
   if (data_stack_constr(stack)) {stack}

--- a/R/add_candidates.R
+++ b/R/add_candidates.R
@@ -430,7 +430,8 @@ check_name <- function(name) {
     if (make.names(name) != name) {
       glue_message(
         "The inputted `name` argument cannot prefix a valid column name. The ", 
-        'data stack will use "{make.names(name)}" rather than "{name}".'
+        'data stack will use "{make.names(name)}" rather than "{name}" in ',
+        "constructing candidate names."
       )
     }
   }

--- a/R/add_candidates.R
+++ b/R/add_candidates.R
@@ -111,7 +111,7 @@ add_candidates.tune_results <- function(data_stack, candidates,
                                         ...) {
   check_add_data_stack(data_stack)
   check_candidates(candidates)
-  check_name(name)
+  col_name <- check_name(name)
   
   stack <- 
     data_stack %>%
@@ -120,8 +120,8 @@ add_candidates.tune_results <- function(data_stack, candidates,
     .set_outcome(candidates) %>%
     .set_mode_(candidates, name) %>%
     .set_training_data(candidates, name) %>%
-    .set_model_defs_candidates(candidates, name) %>%
-    .set_data_candidates(candidates, name)
+    .set_model_defs_candidates(candidates, col_name) %>%
+    .set_data_candidates(candidates, name, col_name)
   
   if (data_stack_constr(stack)) {stack}
 }
@@ -256,7 +256,7 @@ add_candidates.default <- function(data_stack, candidates, name, ...) {
 }
 
 # appends assessment set predictions to a data stack
-.set_data_candidates <- function(stack, candidates, name) {
+.set_data_candidates <- function(stack, candidates, name, col_name) {
   candidate_cols <-
     collate_predictions(candidates) %>%
     dplyr::ungroup() %>%
@@ -270,7 +270,7 @@ add_candidates.default <- function(data_stack, candidates, name, ...) {
       .config
     ) %>%
     dplyr::mutate(
-      .config = process_.config(.config, df = ., name = name)
+      .config = process_.config(.config, df = ., name = col_name)
     ) %>%
     tidyr::pivot_wider(
       id_cols = c(".row", !!tune::.get_tune_outcome_names(candidates)), 
@@ -426,7 +426,16 @@ check_name <- function(name) {
     )
   } else {
     check_inherits(name, "character")
+    
+    if (make.names(name) != name) {
+      glue_message(
+        "The inputted `name` argument cannot prefix a valid column name. The ", 
+        'data stack will use "{make.names(name)}" rather than "{name}".'
+      )
+    }
   }
+  
+  make.names(name)
 }
 
 # takes in the name a .config column and outputs the

--- a/R/fit_members.R
+++ b/R/fit_members.R
@@ -90,7 +90,7 @@ fit_members <- function(model_stack, ...) {
   metrics_dict <- 
     tibble::enframe(model_stack[["model_metrics"]]) %>%
     tidyr::unnest(cols = value) %>%
-    dplyr::mutate(.config = process_.config(.config, ., name = name))
+    dplyr::mutate(.config = process_.config(.config, ., name = make.names(name)))
   
   if (model_stack[["mode"]] == "regression") {
     members_map <- 

--- a/tests/testthat/test_add_candidates.R
+++ b/tests/testthat/test_add_candidates.R
@@ -244,4 +244,11 @@ test_that("model definition naming works as expected", {
       add_candidates(log_res_nn, "log_res_rf"),
     "has the same name"
   )
+  
+  expect_message(
+    st_reg_1 <- 
+      stacks() %>%
+      add_candidates(reg_res_svm, name = "beep bop"),
+    "cannot prefix a valid column name"
+  )
 })

--- a/tests/testthat/test_fit_members.R
+++ b/tests/testthat/test_fit_members.R
@@ -24,6 +24,20 @@ test_that("basic fit_members works", {
     st_log_1_ %>% fit_members()
   )
   
+  expect_message(
+    st_reg_bad_names <- stacks() %>% 
+      add_candidates(reg_res_svm, name = "name with spaces") %>%
+      blend_predictions() %>%
+      fit_members()
+  )
+  
+  expect_message(
+    st_class_bad_names <- stacks() %>% 
+      add_candidates(class_res_rf, name = "name with spaces") %>%
+      blend_predictions() %>%
+      fit_members()
+  )
+  
   # This is functionality that modeltime depends on.
   # Drop a note in #2 if this changes. :-)
   expect_false(!is.null(st_reg_1_[["member_fits"]]))
@@ -34,6 +48,9 @@ test_that("basic fit_members works", {
   
   expect_false(!is.null(st_log_1_[["member_fits"]]))
   expect_false( is.null(st_log_1__[["member_fits"]]))
+  
+  check_inherits(st_reg_bad_names, "linear_stack")
+  check_inherits(st_class_bad_names, "linear_stack")
 })
 
 test_that("fit_members leaves most model stack elements alone", {


### PR DESCRIPTION
Messages when provided a column name that can't prefix a valid column name and fixes `fit_members` errors in that case.

Closes #69.☃️