### PR TITLE
accommodate outcome levels with special characters

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,9 @@
 
 To released as v0.2.2.
 
+* Fixed bug arising from outcome levels that are not valid column 
+  names in the multinomial classification setting. 
+
 # v0.2.1
 
 * Updates for importing workflow sets that use the `add_variables()` 

--- a/R/add_candidates.R
+++ b/R/add_candidates.R
@@ -281,7 +281,8 @@ add_candidates.default <- function(data_stack, candidates, name, ...) {
   
   pred_class_idx <- grepl(pattern = ".pred_class", x = colnames(candidate_cols))
   
-  candidate_cols <- candidate_cols[,!pred_class_idx]
+  candidate_cols <- candidate_cols[,!pred_class_idx] %>% 
+    setNames(., make.names(names(.)))
   
   if (nrow(stack) == 0) {
     stack <- 
@@ -473,7 +474,9 @@ process_.config <- function(.config, df, name) {
 
 # For racing, we only want to keep the candidates with complete resamples. 
 collate_predictions <- function(x) {
-  res <- tune::collect_predictions(x, summarize = TRUE)
+  res <- tune::collect_predictions(x, summarize = TRUE) %>%
+    dplyr::rename_with(make.names, .cols = dplyr::starts_with(".pred"))
+    
   if (inherits(x, "tune_race")) {
     config_counts <- 
       tune::collect_metrics(x, summarize = FALSE) %>% 

--- a/R/fit_members.R
+++ b/R/fit_members.R
@@ -181,7 +181,8 @@ sanitize_classification_names <- function(model_stack, member_names) {
     as.character() %>%
     unique()
   
-  pred_strings <- paste0(".pred_", outcome_levels, "_")
+  pred_strings <- paste0(".pred_", outcome_levels, "_") %>% 
+    make.names()
   
   new_member_names <-
     gsub(

--- a/R/predict.R
+++ b/R/predict.R
@@ -93,7 +93,8 @@ predict.model_stack <- function(object, new_data, type = NULL, members = FALSE,
       opts = opts,
       type = member_type
     ) %>%
-    rlang::eval_tidy()
+    rlang::eval_tidy() %>%
+    setNames(., make.names(names(.)))
   
   res <- stack_predict(object$equations[[type]], member_preds)
   


### PR DESCRIPTION
Fixes #88 and related to #51!

``` r
# load packages
library(stacks)
library(tidymodels)
#> Registered S3 method overwritten by 'tune':
#>   method                   from   
#>   required_pkgs.model_spec parsnip
library(palmerpenguins)

# change the species so that it has a - in it
dat <- penguins %>%
  mutate(species = paste0(species, "-1"))

# tune a glmnet model w 3 penalties
tuned <- recipe(species ~ bill_length_mm + bill_depth_mm +
                  flipper_length_mm, data = dat) %>%
  step_impute_mean(all_numeric_predictors()) %>%
  workflow(multinom_reg(engine = "glmnet", penalty = tune())) %>%
  tune_grid(dat %>% vfold_cv(3),
            metrics = metric_set(mn_log_loss),
            grid = crossing(penalty = c(.0001, .001, .01)),
            control = control_stack_grid())

# stack em!
st <- stacks() %>%
  add_candidates(tuned) %>%
  blend_predictions() %>%
  fit_members()

# predict on new data
predict(st, dat)
#> # A tibble: 344 × 1
#>    .pred_class
#>    <fct>      
#>  1 Adelie-1   
#>  2 Adelie-1   
#>  3 Adelie-1   
#>  4 Chinstrap-1
#>  5 Adelie-1   
#>  6 Adelie-1   
#>  7 Adelie-1   
#>  8 Adelie-1   
#>  9 Adelie-1   
#> 10 Adelie-1   
#> # … with 334 more rows

# plot
autoplot(st)
```

![](https://i.imgur.com/AcVBjdJ.png)

<sup>Created on 2021-08-26 by the [reprex package](https://reprex.tidyverse.org) (v2.0.0)</sup>

Is there a more tidymodels-esque way to handle this? I think my main concern here is re:

``` r
make.names("adelie-1") == make.names("adelie*1")
#> [1] TRUE
```

<sup>Created on 2021-08-26 by the [reprex package](https://reprex.tidyverse.org) (v2.0.0)</sup>

Also, could we drop a test following from this reprex in {extratests}?