### PR TITLE
handle `"class"`-like outcome names and levels

### DIFF
--- a/R/add_candidates.R
+++ b/R/add_candidates.R
@@ -279,10 +279,7 @@ add_candidates.default <- function(data_stack, candidates, name, ...) {
     ) %>%
     dplyr::select(-.row) 
   
-  pred_class_idx <- grepl(pattern = ".pred_class", x = colnames(candidate_cols))
-  
-  candidate_cols <- candidate_cols[,!pred_class_idx] %>% 
-    setNames(., make.names(names(.)))
+  candidate_cols <- remove_class_preds(candidate_cols)
   
   if (nrow(stack) == 0) {
     stack <- 
@@ -502,3 +499,23 @@ collate_predictions <- function(x) {
   }
   res
 }
+
+# given a set of candidate columns, removes those with hard class predictions
+remove_class_preds <- function(x) {
+  lvls <- levels(factor(x[[1]]))
+
+  # gather indices for the columns with class probability predictions
+  prob_preds_idx <- purrr::map(paste0(".pred_", lvls), grepl, x = colnames(x)) %>%
+    purrr::pmap(any) %>%
+    unlist()
+  
+  # select the columns that look like they have probability predictions,
+  # get rid of entries that would have been okayed because of an outcome
+  # level called "class", and re-attach the outcome column itself
+  x[,prob_preds_idx] %>%
+    dplyr::select(where(is.numeric)) %>% 
+    dplyr::bind_cols(x[,1], .) %>%
+    setNames(., make.names(names(.)))
+}
+
+

--- a/R/add_candidates.R
+++ b/R/add_candidates.R
@@ -279,7 +279,9 @@ add_candidates.default <- function(data_stack, candidates, name, ...) {
     ) %>%
     dplyr::select(-.row) 
   
-  candidate_cols <- remove_class_preds(candidate_cols)
+  if (attr(stack, "mode") == "classification") {
+    candidate_cols <- remove_class_preds(candidate_cols)
+  }
   
   if (nrow(stack) == 0) {
     stack <- 

--- a/tests/testthat/test_add_candidates.R
+++ b/tests/testthat/test_add_candidates.R
@@ -286,3 +286,29 @@ test_that("model definition naming works as expected", {
     "cannot prefix a valid column name"
   )
 })
+
+test_that("stacks can handle columns and levels named 'class'", {
+  # waiting on https://github.com/tidymodels/tune/issues/487
+  # to be able to test with entry "class"
+  x <- tibble::tibble(
+    class = sample(c("class_1", "class_2"), 100, replace = TRUE),
+    a = rnorm(100),
+    b = rnorm(100)
+  )
+  
+  res <- tune_grid(
+    logistic_reg(engine = 'glmnet', penalty = tune(), mixture = 1),
+    preprocessor = recipe(class ~ ., x),
+    resamples = vfold_cv(x, 2),
+    grid = 2,
+    control = control_stack_grid()
+  )
+  
+  expect_s3_class(
+    suppressWarnings(
+      stacks() %>% 
+        add_candidates(res)
+    ),
+    "data_stack"
+  )
+})

--- a/tests/testthat/test_add_candidates.R
+++ b/tests/testthat/test_add_candidates.R
@@ -296,10 +296,10 @@ test_that("stacks can handle columns and levels named 'class'", {
     b = rnorm(100)
   )
   
-  res <- tune_grid(
-    logistic_reg(engine = 'glmnet', penalty = tune(), mixture = 1),
-    preprocessor = recipe(class ~ ., x),
-    resamples = vfold_cv(x, 2),
+  res <- tune::tune_grid(
+    parsnip::logistic_reg(engine = 'glmnet', penalty = tune::tune(), mixture = 1),
+    preprocessor = recipes::recipe(class ~ ., x),
+    resamples = rsample::vfold_cv(x, 2),
     grid = 2,
     control = control_stack_grid()
   )


### PR DESCRIPTION
Closes #125.

``` r
library(tidymodels)
library(stacks)

x <- tibble::tibble(
  class = sample(c("class_1", "class_2"), 100, replace = TRUE),
  a = rnorm(100),
  b = rnorm(100)
)

res <- tune_grid(
  logistic_reg(engine = 'glmnet', penalty = tune(), mixture = 1),
  preprocessor = recipe(class ~ ., x),
  resamples = vfold_cv(x, 2),
  grid = 2,
  control = control_stack_grid()
)

stacks() %>%
  add_candidates(res)
#> # A data stack with 1 model definition and 1 candidate member:
#> #   res: 1 model configuration
#> # Outcome: class (factor)
```

<sup>Created on 2022-05-03 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>