### PR TITLE
support `"censored regression"` mode

### DIFF
--- a/R/add_candidates.R
+++ b/R/add_candidates.R
@@ -188,7 +188,7 @@ add_candidates.default <- function(data_stack, candidates, name, ...) {
   stack
 }
 
-# note whether classification or regression
+# note whether classification, regression, or censored regression
 .set_mode_ <- function(stack, candidates, name) {
   wf_spec <- 
     attr(candidates, "workflow") %>%

--- a/R/fit_members.R
+++ b/R/fit_members.R
@@ -97,7 +97,7 @@ fit_members <- function(model_stack, ...) {
     tidyr::unnest(cols = value) %>%
     dplyr::mutate(.config = process_.config(.config, ., name = make.names(name)))
   
-  if (model_stack[["mode"]] == "regression") {
+  if (model_stack[["mode"]] %in% c("regression", "censored regression")) {
     members_map <- 
       tibble::enframe(model_stack[["cols_map"]]) %>%
       tidyr::unnest(cols = value)

--- a/R/predict.R
+++ b/R/predict.R
@@ -86,9 +86,17 @@ predict.model_stack <- function(object, new_data, type = NULL, members = FALSE,
            class =, prob = "prob",
            numeric = "numeric")
   
+  mode_suffix <- 
+    switch(
+      mode,
+      classification = "classification",
+      `censored regression` = ,
+      regression = "regression"
+    )
+  
   member_preds <- 
     rlang::call2(
-      paste0("predict_members_", object[["mode"]]),
+      paste0("predict_members_", mode_suffix),
       model_stack = object,
       coefs = coefs,
       new_data = new_data,
@@ -140,7 +148,7 @@ predict.data_stack <- function(object, ...) {
 
 check_pred_type <- function(object, type) {
   if (is.null(type)) {
-    if (object[["mode"]] == "regression") {
+    if (object[["mode"]] %in% c("regression", "censored regression")) {
       type <- "numeric"
     } else {
       type <- "class"

--- a/R/print.R
+++ b/R/print.R
@@ -2,7 +2,7 @@
 print.data_stack <- function(x, ...) {
   mode <- attr(x, "mode")
   
-  if (mode == "regression") {
+  if (mode %in% c("regression", "censored regression")) {
     n_cands <- ncol(x) - 1
     n_model_defs <- length(attr(x, "model_defs"))
     outcome_name <- colnames(x)[1]
@@ -129,7 +129,7 @@ print_top_coefs <- function(x, penalty = x$penalty$penalty, n = 10, digits = 3) 
   res <- top_coefs(x, penalty = penalty, n = n)
   
   msg <- paste0("\nThe ", nrow(res), " highest weighted member",
-               if (x$mode == "regression") {"s"} else {" classes"},
+               if (!x$mode == "classification") {"s"} else {" classes"},
                " are:")
   rlang::inform(msg)
   print(res)


### PR DESCRIPTION
The nuts and bolts for #152. Currently errors out on [this switch statement in tune](https://github.com/tidymodels/tune/blob/08fc285eff5ba4f04632e2906014ce0be47453fc/R/checks.R#L337-L352), which has no obvious patch for now. Can return to this once needed infrastructure is situated. :)