### PR TITLE
revise errors for workflow sets

### DIFF
--- a/tests/testthat/_snaps/add_candidates.md
+++ b/tests/testthat/_snaps/add_candidates.md
@@ -1,0 +1,14 @@
+# stacks can add candidates via workflow sets
+
+    ! Some elements of the supplied workflow set failed to evaluate with resamples.
+    i The workflow with ID `reg_lr` will be excluded from the data stack.
+
+---
+
+    ! Some elements of the supplied workflow set failed to evaluate with resamples.
+    i The workflows with ID `reg_lr` and `reg2_svm` will be excluded from the data stack.
+
+---
+
+    The supplied workflow set must be fitted to resamples with `workflows::workflow_map()` before being added to a data stack.
+


### PR DESCRIPTION
Fixes #160. Also splits the check into two cases, raising two different conditions.

If there are no fitted workflows in the workflowset, an error:

> The supplied workflow set must be fitted to resamples with `workflows::workflow_map()` before being added to a data stack.

If only some of the workflows aren't fitted, a warning:

>     ! Some elements of the supplied workflow set failed to evaluate with resamples.
>     i The workflows with ID `reg_lr` and `reg2_svm` will be excluded from the data stack.