### PR TITLE
remove `stack_workflow()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,9 @@
 
 * Converted all character variables in the `tree_frogs` example data to factor 
   and updated downstream example objects (#177).
+  
+* Fixed bug that resulted in errors when using model formulas with the 
+  `"mgcv"` engine (#193).
 
 # stacks 1.0.1
 

--- a/R/add_candidates.R
+++ b/R/add_candidates.R
@@ -263,9 +263,7 @@ add_candidates.default <- function(data_stack, candidates, name, ...) {
   model_defs <- attr(stack, "model_defs")
   model_metrics <- attr(stack, "model_metrics")
   
-  model_defs[[name]] <- 
-    attr(candidates, "workflow") %>% 
-    stack_workflow(call = caller_env())
+  model_defs[[name]] <- attr(candidates, "workflow")
   model_metrics[[name]] <- tune::collect_metrics(candidates)
   
   attr(stack, "model_defs") <- model_defs
@@ -390,31 +388,6 @@ update_stack_data <- function(stack, new_data) {
     new_data,
     class = c("data_stack", class(new_data))
   )
-}
-
-# takes in a workflow and returns a minimal workflow for
-# use in the stack
-stack_workflow <- function(x, call) {
-  res <-
-    workflows::workflow() %>%
-    workflows::add_model(workflows::extract_spec_parsnip(x))
-  
-  pre <- workflows::extract_preprocessor(x)
-  
-  if (inherits(pre, "formula")) {
-    res <- res %>% workflows::add_formula(pre)
-  } else if (inherits(pre, "recipe")) {
-    res <- res %>% workflows::add_recipe(pre)
-  } else if (inherits(pre, "workflow_variables")) {
-    res <- res %>% workflows::add_variables(variables = pre)
-  } else {
-    cli_abort(
-      "Can't add a preprocessor of class '{class(pre)[1]}'",
-      call = call
-    )
-  }
-  
-  res
 }
 
 check_add_data_stack <- function(data_stack) {


### PR DESCRIPTION
stacks stores the workflow saved via `control_grid(save_workflow = TRUE)` in the model stack object in order to be able to train on new data in `fit_members()`. The object size of those workflows, especially w.r.t. recipes, was a concern when we were drafting the package, so we introduced a `stack_workflow()` helper early on with the intent to create a "minimal" workflow. I'm now not sure, though, whether it actually saves us any memory. 

``` r
library(tidymodels)
library(stacks)
  
set.seed(4400)

wflow <- 
  workflow() %>% 
  add_recipe(recipe(mpg ~ ., mtcars[rep(1:32, 3000),])) %>% 
  add_model(linear_reg(engine = "glmnet", penalty = tune()))

res <- tune_grid(wflow, resamples = vfold_cv(mtcars),
                 control = control_stack_grid())
#> ℹ The workflow being saved contains a recipe, which is 8.07 Mb in ℹ memory. If
#> this was not intentional, please set the control setting ℹ `save_workflow =
#> FALSE`.

wf_extract <- attr(res, "workflow")
wf_trimmed <- stacks:::stack_workflow(wf_extract)

object.size(wf_extract)
#> 8468768 bytes
object.size(wf_trimmed)
#> 8468768 bytes

lobstr::obj_size(wf_extract)
#> 8.46 MB
lobstr::obj_size(wf_trimmed)
#> 8.46 MB
```

<sup>Created on 2023-03-30 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

The workflows in that `attr()` are not trained, and in the cases where `stack_workflow()` does save any memory, it seems like it actually ends up generating invalid workflows (see linked issue).

Is it true that untrained workflows are as "light" as they can be? Am I missing a side effect of `workflows::extract_preprocessor(recipe)` that is actually helpful for us here?

Closes #193.