### PR TITLE
test with dev yardstick

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,7 +36,7 @@ Imports:
     tune (>= 0.1.3),
     vctrs (>= 0.6.1),
     workflows (>= 0.2.3),
-    yardstick
+    yardstick (>= 1.1.0.9001)
 Suggests: 
     covr,
     h2o,
@@ -54,7 +54,8 @@ Suggests:
 VignetteBuilder: 
     knitr
 Remotes:
-    tidyverse/dplyr
+    tidyverse/dplyr,
+    tidymodels/yardstick
 Config/Needs/website: tidyverse/tidytemplate
 Config/testthat/edition: 3
 Encoding: UTF-8


### PR DESCRIPTION
**Do not merge!**

Was able to replicate this failure with CRAN stacks---confirming that the check failure with dev yardstick has indeed been fixed.

```
Changes to worse in reverse depends:

Package: stacks
Check: re-building of vignette outputs
New result: ERROR
  Error(s) in re-building vignettes:
    ...
  --- re-building ‘basics.Rmd’ using rmarkdown
  Quitting from lines 406-408 (basics.Rmd) 
  Error: processing vignette ‘basics.Rmd’ failed with diagnostics:
  ℹ In index: 1.
  ℹ With name: latency.
  Caused by error in `vars_select_eval()`:
  ! Can't subset columns past the end.
  ℹ Locations 180, 39, 224, …, 160, and 183 don't exist.
  ℹ There are only 7 columns.
  --- failed re-building ‘basics.Rmd’
  
  --- re-building ‘classification.Rmd’ using rmarkdown
  --- finished re-building ‘classification.Rmd’
  
  SUMMARY: processing the following file failed:
    ‘basics.Rmd’
  
  Error: Vignette re-building failed.
  Execution halted
```