### PR TITLE
try documenting with dev roxygen2

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -58,4 +58,4 @@ Config/testthat/edition: 3
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.3
+RoxygenNote: 7.2.3.9000

--- a/man/stacks_description.Rd
+++ b/man/stacks_description.Rd
@@ -3,7 +3,6 @@
 \docType{package}
 \name{stacks_description}
 \alias{stacks_description}
-\alias{_PACKAGE}
 \alias{stacks_package}
 \alias{stacks-package}
 \title{stacks: Tidy Model Stacking}


### PR DESCRIPTION
The `_PACKAGE` alias was dropped in the expected, package-level docs rather than `?stacks::stacks()`--score. :)