### PR TITLE
add support for parallelism with future

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: stacks
 Title: Tidy Model Stacking
-Version: 1.0.3.9000
+Version: 1.0.3.9001
 Authors@R: c(
     person("Simon", "Couch", , "simon.couch@posit.co", role = c("aut", "cre")),
     person("Max", "Kuhn", , "max@posit.co", role = "aut"),
@@ -19,8 +19,10 @@ Depends:
 Imports:
     butcher (>= 0.1.3),
     cli,
+    doFuture,
     dplyr (>= 1.1.0),
     foreach,
+    future,
     generics,
     ggplot2,
     glmnet,
@@ -58,4 +60,4 @@ Config/testthat/edition: 3
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.3.9000
+RoxygenNote: 7.3.1

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # stacks (development version)
 
+* Introduced support for parallel processing using the [future](https://www.futureverse.org/) framework. The stacks package previously supported parallelism with foreach, and users can use either framework for now. In a future release, stacks will begin the deprecation cycle for parallelism with foreach, so we encourage users to begin migrating their code now. See [the _Parallel Processing_ section in the tune package's "Optimizations" article](https://tune.tidymodels.org/articles/extras/optimizations.html#parallel-processing) to learn more (#866).
+
 * Improved error message for unsupported model modes (#152).
 
 # stacks 1.0.3

--- a/R/fit_members.R
+++ b/R/fit_members.R
@@ -129,21 +129,19 @@ fit_members <- function(model_stack, ...) {
   }
   
   # fit each of them
-  rlang::with_options(
-    doFuture.rng.onMisuse = "ignore",
-    .expr = {
-      member_fits <- 
-        foreach::foreach(mem = member_names, .inorder = FALSE) %do_op% {
-          asNamespace("stacks")$fit_member(
-            name = mem,
-            wflows = model_stack[["model_defs"]],
-            members_map = members_map,
-            train_dat = dat
-          )
-        }
+  member_fits <- 
+    foreach::foreach(
+      mem = member_names,
+      .inorder = FALSE,
+      .options.future = list(seed = TRUE)
+    ) %do_op% {
+      asNamespace("stacks")$fit_member(
+        name = mem,
+        wflows = model_stack[["model_defs"]],
+        members_map = members_map,
+        train_dat = dat
+      )
     }
-  )
-
   
   model_stack[["member_fits"]] <- 
     setNames(member_fits, member_names)

--- a/man/fit_members.Rd
+++ b/man/fit_members.Rd
@@ -24,8 +24,8 @@ stack's predictions, members should be trained on the full
 training set using \code{fit_members()}.
 }
 \details{
-To fit members in parallel, please register a parallel backend function.
-See the documentation of \code{\link[foreach:foreach]{foreach::foreach()}} for examples.
+To fit members in parallel, please create a plan with the future package.
+See the documentation of \code{\link[future:plan]{future::plan()}} for examples.
 }
 \section{Example Data}{
 


### PR DESCRIPTION
Related to tidymodels/tune#866, but a bit more straightforward here. :)

This PR uses future's RNG scheme when using doFuture; while tune has its own RNG machinery that guarantees reproducibility between sequential and parallel runs, stacks did not. Going ahead and transitioning to future's RNG scheme is thus no more breaking than not doing so, and means that users will see no change when foreach is fully written out in a later release.