### PR TITLE
address inflation of `model_stack` object size after saving and reloading

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # stacks (development version)
 
+* Addressed inflation of butchered model stack object size after saving and
+  reloading (#214).
+
 # stacks 1.0.4
 
 * Introduced support for parallel processing using the [future](https://www.futureverse.org/) framework. The stacks package previously supported parallelism with foreach, and users can use either framework for now. In a future release, stacks will begin the deprecation cycle for parallelism with foreach, so we encourage users to begin migrating their code now. See [the _Parallel Processing_ section in the tune package's "Optimizations" article](https://tune.tidymodels.org/articles/extras/optimizations.html#parallel-processing) to learn more (#866).

--- a/R/blend_predictions.R
+++ b/R/blend_predictions.R
@@ -357,6 +357,11 @@ check_blend_data_stack <- function(data_stack) {
 
 process_data_stack <- function(data_stack) {
   dat <- tibble::as_tibble(data_stack) %>% na.omit()
+
+  # retain only the tbl_df attributes (#214)
+  attributes(dat) <- attributes(dat)[
+    names(attributes(tibble::new_tibble(list())))
+  ]
   
   if (nrow(dat) == 0) {
     cli_abort(


### PR DESCRIPTION
Closes #214. 

Model stacks will still be larger after saving/reloading if not butchered, but when butchered, the saved and reloaded object will be comparable in size to the original.

```r
# object after reloading
lobstr::obj_size(stack_finalized)
#> 2.62 GB
# original object
lobstr::obj_size(stack_finalized_orig)
#> 1.63 GB

# butchered object after reloading
lobstr::obj_size(stack_finalized_butchered)
#> 48.59 MB
# butchered original object
lobstr::obj_size(stack_finalized_butchered_orig)
#> 47.14 MB
```