### PR TITLE
Modify vignettes and articles to match tidy formatting

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # stacks (development version)
 
+* Added missing commas and formatting issues throughout the vignettes and articles. Backticks for package names were removed, and missing parentheses for functions were added. (@Joscelinrocha, #218).
+  
 # stacks 1.0.5
 
 * Addressed inflation of butchered model stack object size after saving and

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # stacks (development version)
 
-* Added missing commas and formatting issues throughout the vignettes and articles. Backticks for package names were removed, and missing parentheses for functions were added. (@Joscelinrocha, #218).
+* Added missing commas and addressed formatting issues throughout the vignettes and articles. Backticks for package names were removed and missing parentheses for functions were added (@Joscelinrocha, #218).
   
 # stacks 1.0.5
 

--- a/vignettes/articles/workflowsets.Rmd
+++ b/vignettes/articles/workflowsets.Rmd
@@ -69,11 +69,11 @@ library(purrr)
 library(ggplot2)
 ```
 
-In this example, we'll again make use of the `tree_frogs` data exported with `stacks`, giving experimental results on hatching behavior of red-eyed tree frog embryos! 
+In this example, we'll again make use of the `tree_frogs` data exported with stacks, giving experimental results on hatching behavior of red-eyed tree frog embryos! 
 
 Red-eyed tree frog (RETF) embryos can hatch earlier than their normal 7ish days if they detect potential predator threat. Researchers wanted to determine how, and when, these tree frog embryos were able to detect stimulus from their environment. To do so, they subjected the embryos at varying developmental stages to "predator stimulus" by jiggling the embryos with a blunt probe. Beforehand, though some of the embryos were treated with gentamicin, a compound that knocks out their lateral line (a sensory organ.) Researcher Julie Jung and her crew found that these factors inform whether an embryo hatches prematurely or not!
 
-We'll start out with predicting `latency` (i.e. time to hatch) based on other attributes. We'll need to filter out NAs (i.e. cases where the embryo did not hatch) first.
+We'll start out with predicting `latency` (i.e., time to hatch) based on other attributes. We'll need to filter out NAs (i.e., cases where the embryo did not hatch) first.
 
 ```{r, message = FALSE, warning = FALSE}
 data("tree_frogs")
@@ -196,7 +196,7 @@ svm_rec <-
   step_normalize(all_numeric_predictors())
 ```
 
-With each model specification and accompanying recipe now defined, we can combine them via `workflow_set`:
+With each model specification and accompanying recipe now defined, we can combine them via `workflow_set()`:
 
 ```{r}
 wf_set <- 
@@ -303,9 +303,11 @@ Juxtaposing the predictions with the true data:
 
 ```{r, fig.alt = "A ggplot scatterplot showing observed versus predicted latency values. While there is indeed a positive and roughly linear relationship, there is certainly patterned structure in the residuals."}
 ggplot(tree_frogs_test) +
-  aes(x = latency, 
-      y = .pred) +
-  geom_point() + 
+  aes(
+    x = latency,
+    y = .pred
+  ) +
+  geom_point() +
   coord_obs_pred()
 ```
 

--- a/vignettes/basics.Rmd
+++ b/vignettes/basics.Rmd
@@ -61,7 +61,7 @@ In this example, we'll make use of the `tree_frogs` data exported with `stacks`,
 
 Red-eyed tree frog (RETF) embryos can hatch earlier than their normal 7ish days if they detect potential predator threat. Researchers wanted to determine how, and when, these tree frog embryos were able to detect stimulus from their environment. To do so, they subjected the embryos at varying developmental stages to "predator stimulus" by jiggling the embryos with a blunt probe. Beforehand, though some of the embryos were treated with gentamicin, a compound that knocks out their lateral line (a sensory organ.) Researcher Julie Jung and her crew found that these factors inform whether an embryo hatches prematurely or not!
 
-We'll start out with predicting `latency` (i.e. time to hatch) based on other attributes. We'll need to filter out NAs (i.e. cases where the embryo did not hatch) first.
+We'll start out with predicting `latency` (i.e., time to hatch) based on other attributes. We'll need to filter out NAs (i.e., cases where the embryo did not hatch) first.
 
 ```{r, message = FALSE, warning = FALSE}
 data("tree_frogs")
@@ -385,9 +385,11 @@ Juxtaposing the predictions with the true data:
 
 ```{r, fig.alt = "A ggplot scatterplot showing observed versus predicted latency values. While there is indeed a positive and roughly linear relationship, there is certainly patterned structure in the residuals."}
 ggplot(tree_frogs_test) +
-  aes(x = latency, 
-      y = .pred) +
-  geom_point() + 
+  aes(
+    x = latency,
+    y = .pred
+  ) +
+  geom_point() +
   coord_obs_pred()
 ```
 

--- a/vignettes/classification.Rmd
+++ b/vignettes/classification.Rmd
@@ -73,9 +73,11 @@ theme_set(theme_bw())
 ggplot(tree_frogs) +
   aes(x = treatment, y = age, color = reflex) +
   geom_jitter() +
-  labs(y = "Embryo Age (s)", 
-       x = "treatment",
-       color = "Response")
+  labs(
+    y = "Embryo Age (s)",
+    x = "treatment",
+    color = "Response"
+  )
 ```
 
 It looks like the embryo age is pretty effective at picking out embryos with full VOR function, but the problem gets tougher for the less developed embryos! Let's see how well the stacked ensemble can classify these tree frogs.


### PR DESCRIPTION
Added missing commas and formatting issues throughout the vignettes and articles. Backticks for package names were removed, and missing parentheses for functions were added.

These changes fix issue #218