### PR TITLE
remove support for foreach

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,8 +20,8 @@ Depends:
 Imports:
     butcher (>= 0.1.3),
     cli,
-    doFuture,
     dplyr (>= 1.1.0),
+    foreach,
     furrr,
     future,
     generics,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,7 +22,7 @@ Imports:
     cli,
     doFuture,
     dplyr (>= 1.1.0),
-    foreach,
+    furrr,
     future,
     generics,
     ggplot2,

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,10 @@
 * Added missing commas and addressed formatting issues throughout the vignettes and articles. Backticks for package names were removed and missing parentheses for functions were added (@Joscelinrocha, #218).
 
 * Increased the minimum R version to R 4.1.
+
+* Transitioned support for parallel processing fully to the 
+  [future](https://www.futureverse.org/) framework. Parallelism backends
+  registered with foreach will be ignored (#234).
   
 # stacks 1.0.5
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,7 +9,7 @@
 
 * Transitioned support for parallel processing fully to the 
   [future](https://www.futureverse.org/) framework. Parallelism backends
-  registered with foreach will be ignored (#234).
+  registered with foreach will be ignored with a warning (#234).
   
 # stacks 1.0.5
 

--- a/R/fit_members.R
+++ b/R/fit_members.R
@@ -129,6 +129,10 @@ fit_members <- function(model_stack, ...) {
       )
   }
 
+  if (uses_foreach_only()) {
+    warn_foreach_deprecation()
+  }
+
   # fit each of them
   member_fits <-
     furrr::future_map(
@@ -253,7 +257,8 @@ check_for_required_packages <- function(x) {
 
   purrr::map(
     pkgs,
-    function(.x) suppressPackageStartupMessages(requireNamespace(.x, quietly = TRUE))
+    function(.x)
+      suppressPackageStartupMessages(requireNamespace(.x, quietly = TRUE))
   )
 
   invisible(TRUE)
@@ -273,4 +278,18 @@ error_needs_install <- function(pkgs, installed, call) {
 
 is_installed_ <- function(pkg) {
   rlang::is_installed(pkg)
+}
+
+uses_foreach_only <- function() {
+  future::nbrOfWorkers() == 1 && foreach::getDoParWorkers() > 1
+}
+
+warn_foreach_deprecation <- function() {
+  cli::cli_warn(c(
+    "!" = "{.pkg stacks} detected a parallel backend registered with \\
+           foreach but no backend registered with future.",
+    "i" = "Support for parallel processing with foreach was \\
+           deprecated in {.pkg stacks} 1.0.6.",
+    "i" = "See {.help tune::parallelism} to learn more."
+  ))
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -21,6 +21,7 @@ utils::globalVariables(c(
   ".metric",
   ".pred",
   ".pred_class",
+  ".sum",
   "across",
   "any_of",
   "as.formula",


### PR DESCRIPTION
Closes #234.

Looks like we first introduced support for future in this package a little over a year ago. Opted not to raise a warning with only a foreach backend registered, as CRAN tune does, as it would be redundant with that warning.